### PR TITLE
feat: allow configuring search bar icon

### DIFF
--- a/src/wofi.c
+++ b/src/wofi.c
@@ -231,9 +231,25 @@ static gboolean do_search(gpointer data) {
 	return G_SOURCE_CONTINUE;
 }
 
-static GIcon*
-get_icon_from_string(const char* src)
+static void
+filter_character_out(char* src, const char ch)
 {
+	const char delimiter[2] = {ch, '\0'};
+	char* token = strtok(src, delimiter);
+
+	while (token != NULL)
+	{
+		sprintf(src, "%s", token);
+		token = strtok(NULL, delimiter);
+	}
+}
+
+static GIcon*
+get_icon_from_string(char* src)
+{
+	filter_character_out(src, '\'');
+	filter_character_out(src, '"');
+
 	GIcon* icon = NULL;
 	GFile* fptr = g_file_new_for_path(src);
 


### PR DESCRIPTION
For context: https://github.com/SimplyCEO/wofi/issues/20

Very basic implementation, uses the value of `entry_icon` in the config for selecting an icon from the system gtk icons. May require some finishing touches.

This is not a breaking change, as the icon does not get changed when no value is specified in the config.