### PR TITLE
Define __USE_GNU before including dlcfn.h, to prevent compile error

### DIFF
--- a/src/wofi.c
+++ b/src/wofi.c
@@ -18,7 +18,9 @@
 #include <wofi.h>
 
 #include <ctype.h>
-#define __USE_GNU
+#if defined(__GLIBC__) && (__GLIBC__ <= 2 && __GLIBC_MINOR__ <= 35)
+# define __USE_GNU
+#endif
 #include <dlfcn.h>
 #include <errno.h>
 #include <string.h>


### PR DESCRIPTION
Compilation failed for me with the following error:

```
/home/omf/code/build/wofi/src/wofi.c: In function ‘get_plugin_proc’:                  
/home/omf/code/build/wofi/src/wofi.c:1603:28: error: ‘RTLD_DEFAULT’ undeclared (first use in this function)                                                                  
 1603 |         void* proc = dlsym(RTLD_DEFAULT, proc_name);                                                                                                                 
      |                            ^~~~~~~~~~~~                                                                                                                              
/home/omf/code/build/wofi/src/wofi.c:1603:28: note: each undeclared identifier is reported only once for each function it appears in                                         
gmake[2]: *** [CMakeFiles/wofi.dir/build.make:272: CMakeFiles/wofi.dir/src/wofi.c.o] Error 1                                                                                 
gmake[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/wofi.dir/all] Error 2    
```

It appears `__USE_GNU` needs to be defined before including dlcfn.h.